### PR TITLE
Fix missing package files for memoriax2

### DIFF
--- a/memoriax2/utils/text_embedding.py
+++ b/memoriax2/utils/text_embedding.py
@@ -1,0 +1,3 @@
+from memoriax2.nlp.embedding import embed_text
+
+__all__ = ['embed_text']


### PR DESCRIPTION
## Summary
- add missing package initializer so `memoriax2` can be imported
- expose `embed_text` via new utility module for backwards compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: vaderSentiment)*

------
https://chatgpt.com/codex/tasks/task_e_6841a9ad3b38833292822dffd55b6571