### PR TITLE
Remove stray __init__ function

### DIFF
--- a/memoriax2/core/chatbot.py
+++ b/memoriax2/core/chatbot.py
@@ -124,9 +124,6 @@ def make_response_more_empathetic(response):
     # Basic implementation to make the response more empathetic
     return f"This is an empathetic response: {response}"
 
-def __init__(self, embedding_dim: int):
-    self.index = faiss.IndexFlatL2(embedding_dim)  # Set the index dimension dynamically
-    self.id_map = {}
 
 def conversation_mode(user_input, conn):
     # Check for recent messages


### PR DESCRIPTION
## Summary
- clean up `chatbot.py` by removing a stray standalone `__init__` function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `spacy` and `numpy`)*

------
https://chatgpt.com/codex/tasks/task_e_68437e8201fc8332b740581db421e54f