### PR TITLE
Unify store_in_db function

### DIFF
--- a/memoriax2/core/chatbot.py
+++ b/memoriax2/core/chatbot.py
@@ -1,5 +1,10 @@
 from memoriax2.nlp.processor import analyze_input  # Import the analyze_input function from the memoriax2.nlp.processor module
-from memoriax2.storage.database import mark_confirmed, store_in_db, store_memory, retrieve_memory  # Import store_memory and retrieve_memory functions from the memoriax2.storage.database module
+from memoriax2.storage.database import (
+    mark_confirmed,
+    store_in_db,
+    store_memory,
+    retrieve_memory,
+)
 from memoriax2.nlp.emotion import detect_emotion
 from memoriax2.nlp.memory_recall import retrieve_similar_memories, embed_text
 import faiss
@@ -42,8 +47,8 @@ def process_input(user_input, conn, session_id, memory_index):
         generated_key = f"entry_{uuid.uuid4()}"
         print(f"Generated memory key: {generated_key}")
 
-        # Log the turn
-        store_in_db(conn, user_input, response, emotion)
+        # Log the turn in the messages table
+        store_message_in_db(conn, user_input, response, emotion)
         print("Logged the turn in the database.")
 
         # Store memory explicitly
@@ -277,7 +282,7 @@ def load_index_from_db(self, conn):
 
     #print(f"[MemoryIndex] Loaded {len(rows)} items from DB into FAISS index.")
 
-def store_in_db(conn, user_input, response, emotion):
+def store_message_in_db(conn, user_input, response, emotion):
     cursor = conn.cursor()
     cursor.execute("""
         SELECT COUNT(*) FROM messages

--- a/memoriax2/tests/test_emotion.py
+++ b/memoriax2/tests/test_emotion.py
@@ -19,18 +19,18 @@ class TestDatabaseStorage(unittest.TestCase):
     def test_store_in_db(self):
         session_id = "test_session"
         memory_key = "test_key"
-        user_input = "I am happy"
         response = "That's great to hear!"
         emotion = "happy"
-        store_in_db(self.conn, session_id, memory_key, user_input, response, emotion)
+        store_in_db(self.conn, session_id, memory_key, response, emotion)
         cursor = self.conn.cursor()
         cursor.execute("SELECT * FROM session_messages WHERE session_id=? AND user_input=?", (session_id, memory_key))
         result = cursor.fetchone()
         self.assertIsNotNone(result)
-        self.assertEqual(result[0], session_id)
-        self.assertEqual(result[1], memory_key)
-        self.assertEqual(result[2], response)
-        self.assertEqual(result[3], emotion)
+        # result tuple layout: (id, session_id, user_input, response, emotion)
+        self.assertEqual(result[1], session_id)
+        self.assertEqual(result[2], memory_key)
+        self.assertEqual(result[3], response)
+        self.assertEqual(result[4], emotion)
 
 class TestResponseGeneration(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- remove name clash by renaming `store_in_db` inside chatbot module
- call new `store_message_in_db` when logging conversation turns
- adjust tests for updated `store_in_db` API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'spacy')*

------
https://chatgpt.com/codex/tasks/task_e_68437e82de3c83328ea66981a5f0cf81